### PR TITLE
Fix taxes value calculation

### DIFF
--- a/app/taxes.js
+++ b/app/taxes.js
@@ -31,7 +31,7 @@ function evaluateTaxes(transactionAmount, accountId){
       formula = formula.replace("transactionAmount", transactionAmount)
       var taxMap = {
         name:key,
-        value:math.evaluate(formula)
+        value:Math.round(math.evaluate(formula))
       }
       taxesList.push(taxMap)
     }


### PR DESCRIPTION
Issue:
The current calculation generates a decimal object, that generates an error on the actual api.

Solution:
Round used on decimal to be converted to integer.